### PR TITLE
ci(Mergify): prevent creating PRs to main other than staging

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,15 +1,27 @@
 pull_request_rules:
+  - name: Automatically decline PRs to main that do not come from the staging branch
+    description: The main branch cannot contain additional commits not present in
+      the staging branch.
+    conditions:
+      - base = main
+      - head != staging
+    actions:
+      review:
+        type: REQUEST_CHANGES
+      close:
+        message: Please make your changes directly on the staging branch and create the
+          pull request from the staging branch to main!
   - name: Automatically merge safe indirection PRs
     description: Merge when PR contains additions made by the backend CMS on site launch
     conditions:
       - base = main
       - head = staging
       - files~=^dns/
-      - '#commits = 1'
-      - '#files = 1'
-      - '#added-lines = 34'
-      - '#deleted-lines = 0'
+      - "#commits = 1"
+      - "#files = 1"
+      - "#added-lines = 34"
+      - "#deleted-lines = 0"
     actions:
       review:
         type: APPROVE
-      merge: 
+      merge:


### PR DESCRIPTION
This change has been made by @dcshzj from the Mergify workflow automation editor.